### PR TITLE
Update Redis to 5.0.3

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+# Improvements
+
+- Upgraded Redis to 5.0.3

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 redis/redis-5.0.3.tar.gz:
   size: 1959445
+  object_id: 3823037e-64fd-4a00-7b5c-2c775af9c6b9
   sha: a43c24ea6365482323b78e21752d610756efcc39

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,5 +1,3 @@
----
-redis/redis-3.2.6.tar.gz:
-  object_id: 8acacbb6-4123-4d80-ba3f-59c6467bfb0b
-  sha: 0c7bc5c751bdbc6fabed178db9cdbdd948915d1b
-  size: 1544806
+redis/redis-5.0.3.tar.gz:
+  size: 1959445
+  sha: a43c24ea6365482323b78e21752d610756efcc39

--- a/packages/redis/packaging
+++ b/packages/redis/packaging
@@ -8,7 +8,7 @@ CPUS=$(grep -c ^processor /proc/cpuinfo)
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 export HOME=/var/vcap
 
-tar -xzvf redis/redis-3.2.6.tar.gz
-cd redis-3.2.6
+tar -xzvf redis/redis-5.0.3.tar.gz
+cd redis-5.0.3
 export PREFIX=${BOSH_INSTALL_TARGET}
 make && make install

--- a/packages/redis/spec
+++ b/packages/redis/spec
@@ -2,4 +2,4 @@
 name: redis
 dependencies: []
 files:
-  - redis/redis-3.2.6.tar.gz
+  - redis/redis-5.0.3.tar.gz


### PR DESCRIPTION
This PR upgrades the packaged Redis to 5.0.3, which is currently the latest stable. Verified to work with the current Blacksmith Genesis Kit as intended; no configuration changes were necessary.