### PR TITLE
Drop URL / URLs in Redis Credentials

### DIFF
--- a/jobs/redis-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -1,7 +1,5 @@
 ---
 credentials:
-  url:   (( concat "redis://" jobs.node/0.ips[0] ":6379" ))
-  urls:  (( cartesian-product "redis://" jobs.node.ips ":6379" ))
   host:  (( grab jobs.node/0.ips[0] ))
   hosts: (( grab jobs.node.ips ))
   port:  6379

--- a/jobs/redis-blacksmith-plans/templates/plans/standalone/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/standalone/credentials.yml
@@ -1,6 +1,5 @@
 ---
 credentials:
-  url:  (( concat "redis://" jobs.standalone/0.ips[0] ":6379" ))
   host: (( grab jobs.standalone/0.ips[0] ))
   port: 6379
   password: (( grab meta.password ))


### PR DESCRIPTION
Spring Boot framework apparently prefers the Redis URI over the
constituent pieces and parts of host / port / username / password.
Since URL did not include auth credentials, this caused issues for
Spring apps.