### PR TITLE
Update to Redis 5.0.14, 6.2.6, and Bionic stemcells

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,8 +1,8 @@
-redis/redis-5.0.12.tar.gz:
-  size: 1995069
-  object_id: c075dd4b-1418-4f41-5b78-4028cc5f63a5
-  sha: sha256:7040eba5910f7c3d38f05ea5a1d88b480488215bdbd2e10ec70d18380108e31e
-redis/redis-6.2.1.tar.gz:
-  size: 2438367
-  object_id: ee355ec1-3a46-4afd-4b86-230710d3d46b
-  sha: sha256:cd222505012cce20b25682fca931ec93bd21ae92cb4abfe742cf7b76aa907520
+redis/redis-5.0.14.tar.gz:
+  size: 2000179
+  object_id: 7f4f2ddd-f4e2-417c-7ab9-8e3eebf448ed
+  sha: sha256:3ea5024766d983249e80d4aa9457c897a9f079957d0fb1f35682df233f997f32
+redis/redis-6.2.6.tar.gz:
+  size: 2476542
+  object_id: 4d641599-47c3-4342-67fa-0d1720555c52
+  sha: sha256:5b2b8b7a50111ef395bf1c1d5be11e6e167ac018125055daa8b5c2317ae131ab

--- a/jobs/redis-blacksmith-plans/templates/plans/cluster-6/manifest.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/cluster-6/manifest.yml
@@ -13,7 +13,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-xenial
+  os: ubuntu-bionic
   version: latest
 
 update:

--- a/jobs/redis-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -13,7 +13,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-xenial
+  os: ubuntu-bionic
   version: latest
 
 update:

--- a/jobs/redis-blacksmith-plans/templates/plans/standalone-6/manifest.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/standalone-6/manifest.yml
@@ -10,7 +10,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-xenial
+  os: ubuntu-bionic
   version: latest
 
 update:

--- a/jobs/redis-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -10,7 +10,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-xenial
+  os: ubuntu-bionic
   version: latest
 
 update:

--- a/packages/redis-6/packaging
+++ b/packages/redis-6/packaging
@@ -8,7 +8,7 @@ CPUS=$(grep -c ^processor /proc/cpuinfo)
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 export HOME=/var/vcap
 
-tar -xzvf redis/redis-6.2.1.tar.gz
-cd redis-6.2.1
+tar -xzvf redis/redis-6.2.6.tar.gz
+cd redis-6.2.6
 export PREFIX=${BOSH_INSTALL_TARGET}
 make BUILD_TLS=yes -j$CPUS && make install

--- a/packages/redis-6/spec
+++ b/packages/redis-6/spec
@@ -2,4 +2,4 @@
 name: redis-6
 dependencies: []
 files:
-  - redis/redis-6.2.1.tar.gz
+  - redis/redis-6.2.6.tar.gz

--- a/packages/redis/packaging
+++ b/packages/redis/packaging
@@ -8,7 +8,7 @@ CPUS=$(grep -c ^processor /proc/cpuinfo)
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 export HOME=/var/vcap
 
-tar -xzvf redis/redis-5.0.12.tar.gz
-cd redis-5.0.12
+tar -xzvf redis/redis-5.0.14.tar.gz
+cd redis-5.0.14
 export PREFIX=${BOSH_INSTALL_TARGET}
 make -j$CPUS && make install

--- a/packages/redis/spec
+++ b/packages/redis/spec
@@ -2,4 +2,4 @@
 name: redis
 dependencies: []
 files:
-  - redis/redis-5.0.12.tar.gz
+  - redis/redis-5.0.14.tar.gz


### PR DESCRIPTION
# Improvements

* Stemcell updated to use Bionic (requires Blacksmith-genesis-kit with Bionic or Bionic stemcell manually uploaded)
* Redis updated to 5.0.14
* Redis-6 updated to 6.2.6