### PR TITLE
Fix ownership on the RSA key

### DIFF
--- a/jobs/standalone-6/templates/bin/pre-start
+++ b/jobs/standalone-6/templates/bin/pre-start
@@ -9,3 +9,6 @@ openssl x509 -req -in $DATA_DIR/redis.csr -CA $JOB_DIR/config/tls/redis.ca_cert 
 
 cp $JOB_DIR/config/tls/redis.ca /usr/local/share/ca-certificates/redis.crt
 update-ca-certificates
+
+chown vcap:vcap $DATA_DIR/*
+


### PR DESCRIPTION
Ensure the RSA key is owned by the BOSH vcap user.