### PR TITLE
Allow custom lists of disabled Redis commands

### DIFF
--- a/jobs/standalone-6/spec
+++ b/jobs/standalone-6/spec
@@ -107,3 +107,9 @@ properties:
   redis.auto-aof-rewrite-min-size:
     description: Modify the minimum file size  for auto append on rewrite.
     default: "64mb"
+
+  redis.disabled-commands:
+    description: |
+      Disable Redis commands, to enable or disable LUA scripting commands
+      use the configuration `lua.scripting-enabled` instead.
+    default: ["CONFIG", "SAVE", "BGSAVE", "DEBUG", "SHUTDOWN", "SLAVEOF", "SYNC", "ACL"]

--- a/jobs/standalone-6/templates/config/redis.conf
+++ b/jobs/standalone-6/templates/config/redis.conf
@@ -36,7 +36,7 @@ timeout <%= p('client.timeout') %>
 tcp-keepalive <%= p('client.tcpkeepalive') %>
 maxclients  <%= p('client.connections') %>
 
-<% p('redis.disabled-commands').each do |cmd| %>
+<% p('redis.disabled-commands').each do |cmd| -%>
 rename-command <%= cmd %> ""
 <% end %>
 

--- a/jobs/standalone-6/templates/config/redis.conf
+++ b/jobs/standalone-6/templates/config/redis.conf
@@ -36,11 +36,9 @@ timeout <%= p('client.timeout') %>
 tcp-keepalive <%= p('client.tcpkeepalive') %>
 maxclients  <%= p('client.connections') %>
 
-rename-command DEBUG ""
-rename-command CONFIG ""
-rename-command SHUTDOWN ""
-rename-command SYNC ""
-rename-command SLAVEOF ""
+<% p('redis.disabled-commands').each do |cmd| %>
+rename-command <%= cmd %> ""
+<% end %>
 
 <% if p('redis.tls.enabled') -%>
 port 6379 


### PR DESCRIPTION
Allow operators to define custom lists of disabled commands. Added to commands disabled by default `ACL`, `SAVE`, `BGSAVE`.