### PR TITLE
Update 6.2.12

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,11 +2,11 @@ redis/redis-5.0.14.tar.gz:
   size: 2000179
   object_id: 7f4f2ddd-f4e2-417c-7ab9-8e3eebf448ed
   sha: sha256:3ea5024766d983249e80d4aa9457c897a9f079957d0fb1f35682df233f997f32
-redis/redis-6.2.6.tar.gz:
-  size: 2476542
-  object_id: 4d641599-47c3-4342-67fa-0d1720555c52
-  sha: sha256:5b2b8b7a50111ef395bf1c1d5be11e6e167ac018125055daa8b5c2317ae131ab
-stunnel/stunnel-5.66.tar.gz:
-  size: 875128
-  object_id: 94097473-0578-4f40-7f89-1dbc28c8f03d
-  sha: sha256:558178704d1aa5f6883aac6cc5d6bbf2a5714c8a0d2e91da0392468cee9f579c
+redis/redis-6.2.12.tar.gz:
+  size: 2516490
+  object_id: 75e5b2c5-febc-4e88-56b7-e08a67d3c7c8
+  sha: sha256:a195479b676221557e0b3ee9f51f824e2b2a2ef4d62ba41960947ff94fe72f14
+stunnel/stunnel-5.69.tar.gz:
+  size: 879988
+  object_id: b344eeed-4062-4685-572b-a903362c16f0
+  sha: sha256:1ff7d9f30884c75b98c8a0a4e1534fa79adcada2322635e6787337b4e38fdb81

--- a/jobs/redis-blacksmith-plans/templates/plans/cluster-6/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/cluster-6/credentials.yml
@@ -2,7 +2,17 @@
 credentials:
   host:  (( grab jobs.node/0.ips[0] ))
   hosts: (( grab jobs.node.ips ))
-  port:  6379
+<% if p("redis.tls.dual-mode") -%>
+  port: 6379
+<% else -%>
+  port: 0
+<% end -%>
   password: (( grab meta.password ))
+<% if p("redis.tls.enabled") -%>
+<% if p("redis.tls.dual-mode") -%>
   tls_port: 16379
+<% else -%>
+  tls_port: 6379
+<% end -%>
   tls_versions: ["tlsv1.2","tlsv1.3"]
+<% end -%>

--- a/jobs/redis-blacksmith-plans/templates/plans/cluster-6/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/cluster-6/credentials.yml
@@ -2,10 +2,10 @@
 credentials:
   host:  (( grab jobs.node/0.ips[0] ))
   hosts: (( grab jobs.node.ips ))
-<% if p("redis.tls.dual-mode") -%>
-  port: 6379
-<% else -%>
+<% if p("redis.tls.enabled") && !p("redis.tls.dual-mode") -%>
   port: 0
+<% else -%>
+  port: 6379
 <% end -%>
   password: (( grab meta.password ))
 <% if p("redis.tls.enabled") -%>

--- a/jobs/redis-blacksmith-plans/templates/plans/cluster-6/manifest.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/cluster-6/manifest.yml
@@ -30,7 +30,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-bionic
+  os: ubuntu-jammy
   version: latest
 
 update:

--- a/jobs/redis-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -2,5 +2,17 @@
 credentials:
   host:  (( grab jobs.node/0.ips[0] ))
   hosts: (( grab jobs.node.ips ))
-  port:  6379
+<% if p("redis.tls.dual-mode") -%>
+  port: 6379
+<% else -%>
+  port: 0
+<% end -%>
   password: (( grab meta.password ))
+<% if p("redis.tls.enabled") -%>
+<% if p("redis.tls.dual-mode") -%>
+  tls_port: 16379
+<% else -%>
+  tls_port: 6379
+<% end -%>
+  tls_versions: ["tlsv1.2","tlsv1.3"]
+<% end -%>

--- a/jobs/redis-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -2,10 +2,10 @@
 credentials:
   host:  (( grab jobs.node/0.ips[0] ))
   hosts: (( grab jobs.node.ips ))
-<% if p("redis.tls.dual-mode") -%>
-  port: 6379
-<% else -%>
+<% if p("redis.tls.enabled") && !p("redis.tls.dual-mode") -%>
   port: 0
+<% else -%>
+  port: 6379
 <% end -%>
   password: (( grab meta.password ))
 <% if p("redis.tls.enabled") -%>

--- a/jobs/redis-blacksmith-plans/templates/plans/cluster/manifest.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/cluster/manifest.yml
@@ -14,7 +14,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-bionic
+  os: ubuntu-jammy
   version: latest
 
 update:

--- a/jobs/redis-blacksmith-plans/templates/plans/standalone-6/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/standalone-6/credentials.yml
@@ -1,10 +1,10 @@
 ---
 credentials:
   host: (( grab jobs.standalone/0.ips[0] ))
-<% if p("redis.tls.dual-mode") -%>
-  port: 6379
-<% else -%>
+<% if p("redis.tls.enabled") && !p("redis.tls.dual-mode") -%>
   port: 0
+<% else -%>
+  port: 6379
 <% end -%>
   password: (( grab meta.password ))
 <% if p("redis.tls.enabled") -%>

--- a/jobs/redis-blacksmith-plans/templates/plans/standalone-6/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/standalone-6/credentials.yml
@@ -1,7 +1,17 @@
 ---
 credentials:
   host: (( grab jobs.standalone/0.ips[0] ))
+<% if p("redis.tls.dual-mode") -%>
   port: 6379
+<% else -%>
+  port: 0
+<% end -%>
   password: (( grab meta.password ))
+<% if p("redis.tls.enabled") -%>
+<% if p("redis.tls.dual-mode") -%>
   tls_port: 16379
+<% else -%>
+  tls_port: 6379
+<% end -%>
   tls_versions: ["tlsv1.2","tlsv1.3"]
+<% end -%>

--- a/jobs/redis-blacksmith-plans/templates/plans/standalone-6/manifest.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/standalone-6/manifest.yml
@@ -27,7 +27,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-bionic
+  os: ubuntu-jammy
   version: latest
 
 update:

--- a/jobs/redis-blacksmith-plans/templates/plans/standalone/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/standalone/credentials.yml
@@ -1,5 +1,17 @@
 ---
 credentials:
   host: (( grab jobs.standalone/0.ips[0] ))
+<% if p("redis.tls.dual-mode") -%>
   port: 6379
+<% else -%>
+  port: 0
+<% end -%>
   password: (( grab meta.password ))
+<% if p("redis.tls.enabled") -%>
+<% if p("redis.tls.dual-mode") -%>
+  tls_port: 16379
+<% else -%>
+  tls_port: 6379
+<% end -%>
+  tls_versions: ["tlsv1.2","tlsv1.3"]
+<% end -%>

--- a/jobs/redis-blacksmith-plans/templates/plans/standalone/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/standalone/credentials.yml
@@ -1,10 +1,10 @@
 ---
 credentials:
   host: (( grab jobs.standalone/0.ips[0] ))
-<% if p("redis.tls.dual-mode") -%>
-  port: 6379
-<% else -%>
+<% if p("redis.tls.enabled") && !p("redis.tls.dual-mode") -%>
   port: 0
+<% else -%>
+  port: 6379
 <% end -%>
   password: (( grab meta.password ))
 <% if p("redis.tls.enabled") -%>

--- a/jobs/redis-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -11,7 +11,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-bionic
+  os: ubuntu-jammy
   version: latest
 
 update:

--- a/jobs/standalone-6/templates/config/redis.conf
+++ b/jobs/standalone-6/templates/config/redis.conf
@@ -48,4 +48,6 @@ tls-key-file /var/vcap/jobs/standalone-6/config/tls/redis.key
 tls-ca-cert-file /var/vcap/jobs/standalone-6/config/tls/redis.ca
 tls-auth-clients no
 tls-protocols "TLSv1.2 TLSv1.3"
+<% else %>
+port 6379
 <% end %>

--- a/packages/redis-6/packaging
+++ b/packages/redis-6/packaging
@@ -8,7 +8,7 @@ CPUS=$(grep -c ^processor /proc/cpuinfo)
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 export HOME=/var/vcap
 
-tar -xzvf redis/redis-6.2.6.tar.gz
-cd redis-6.2.6
+tar -xzvf redis/redis-6.2.12.tar.gz
+cd redis-6.2.12
 export PREFIX=${BOSH_INSTALL_TARGET}
 make BUILD_TLS=yes -j$CPUS && make install

--- a/packages/redis-6/spec
+++ b/packages/redis-6/spec
@@ -2,4 +2,4 @@
 name: redis-6
 dependencies: []
 files:
-  - redis/redis-6.2.6.tar.gz
+  - redis/redis-6.2.12.tar.gz

--- a/packages/stunnel/packaging
+++ b/packages/stunnel/packaging
@@ -10,7 +10,7 @@ CPUS=$(grep -c ^processor /proc/cpuinfo)
 export HOME=/var/vcap
 export PREFIX=${BOSH_INSTALL_TARGET}
 
-VERSION=5.66
+VERSION=5.69
 
 gzip -dc stunnel/stunnel-${VERSION}.tar.gz | tar -xvf -
 cd stunnel-${VERSION} && ./configure --prefix=${PREFIX}

--- a/packages/stunnel/spec
+++ b/packages/stunnel/spec
@@ -2,4 +2,4 @@
 name: stunnel
 dependencies: []
 files:
-- stunnel/stunnel-5.66.tar.gz
+- stunnel/stunnel-5.69.tar.gz


### PR DESCRIPTION
Changes include:

* redis instance default to jammy stemcell 
* credentials generated by redis use conditionals matching the config
* allow redis to define a port if no tls is used
* updates redis to 6.2.12
* updates stunnel to 5.69