### PR TITLE
Add hostname to Redis binding

### DIFF
--- a/jobs/cluster-6/spec
+++ b/jobs/cluster-6/spec
@@ -33,6 +33,8 @@ consumes:
     type: conn
 
 properties:
+  service.type:
+    default: "cluster-6"
   auth.password:
     description: The password required of clients wishing to use this Redis instance.
 

--- a/jobs/cluster/spec
+++ b/jobs/cluster/spec
@@ -22,6 +22,8 @@ consumes:
     type: conn
 
 properties:
+  service.type:
+    default: "cluster"
   auth.password:
     description: The password required of clients wishing to use this Redis instance.
 

--- a/jobs/redis-blacksmith-plans/spec
+++ b/jobs/redis-blacksmith-plans/spec
@@ -56,6 +56,9 @@ properties:
     description: A global limit on the number of Redis services (regardless of the plan); 0 = unlimited.
     default: 0
 
+  service.type:
+    description: Type of redis instance, standalone or cluster
+
   redis.tls.enabled:
     description: "Should the Redis use TLS"
     default: false

--- a/jobs/redis-blacksmith-plans/templates/plans/cluster-6/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/cluster-6/credentials.yml
@@ -1,6 +1,6 @@
 ---
 credentials:
-  host:  (( grab jobs.node/0.ips[0] ))
+  host:  (( grab params.hostname ))
   hosts: (( grab jobs.node.ips ))
 <% if p("redis.tls.enabled") && !p("redis.tls.dual-mode") -%>
   port: 0

--- a/jobs/redis-blacksmith-plans/templates/plans/cluster/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/cluster/credentials.yml
@@ -1,6 +1,6 @@
 ---
 credentials:
-  host:  (( grab jobs.node/0.ips[0] ))
+  host:  (( grab params.hostname ))
   hosts: (( grab jobs.node.ips ))
 <% if p("redis.tls.enabled") && !p("redis.tls.dual-mode") -%>
   port: 0

--- a/jobs/redis-blacksmith-plans/templates/plans/service.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/service.yml
@@ -7,6 +7,7 @@ tags:
   <% p('service.tags', []).each { |tag| %>  - <%= tag %>
   <% } %>
 bindable: true
+type: <%= p('service.type') %>
 metadata: {}
 plan_updateable: true
 <% if p('service.limit') > 0 %>limit: <%= p('service.limit') %><% end %>

--- a/jobs/redis-blacksmith-plans/templates/plans/standalone-6/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/standalone-6/credentials.yml
@@ -1,6 +1,6 @@
 ---
 credentials:
-  host: (( grab jobs.standalone/0.ips[0] ))
+  host: (( grab params.hostname ))
 <% if p("redis.tls.enabled") && !p("redis.tls.dual-mode") -%>
   port: 0
 <% else -%>

--- a/jobs/redis-blacksmith-plans/templates/plans/standalone/credentials.yml
+++ b/jobs/redis-blacksmith-plans/templates/plans/standalone/credentials.yml
@@ -1,6 +1,6 @@
 ---
 credentials:
-  host: (( grab jobs.standalone/0.ips[0] ))
+  host: (( grab params.hostname ))
 <% if p("redis.tls.enabled") && !p("redis.tls.dual-mode") -%>
   port: 0
 <% else -%>

--- a/jobs/standalone-6/spec
+++ b/jobs/standalone-6/spec
@@ -21,6 +21,8 @@ templates:
   dns/aliases.json.erb: dns/aliases.json
 
 properties:
+  service.type:
+    default: "standalone-6"
   auth.password:
     description: The password required of clients wishing to use this Redis instance.
 

--- a/jobs/standalone/spec
+++ b/jobs/standalone/spec
@@ -11,6 +11,8 @@ templates:
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
 
 properties:
+  service.type:
+    default: "standalone"
   auth.password:
     description: The password required of clients wishing to use this Redis instance.
 


### PR DESCRIPTION
When an application connects from CF, it is unable to connect securely over SSL because it's connecting using the IP address of the instance rather than its hostname. In addition, the [RabbitMQ forge boshrelease was updated last year ](https://github.com/blacksmith-community/rabbitmq-forge-boshrelease/pull/81)with a similar change to use its hostname instead of its IP address. This update addresses both the inconsistency and the issue with applications not being able to connect over SSL

