### PR TITLE
Fix cluster MEET port for TLS dual-mode

### DIFF
--- a/jobs/cluster-6/templates/bin/post-deploy
+++ b/jobs/cluster-6/templates/bin/post-deploy
@@ -101,7 +101,7 @@ for ((i = 0; i < len; i++)); do
 
         if [ -n "$ip_a" ] && [ -n "$ip_b" ]; then
             log "Introducing $a ($ip_a) to $b ($ip_b)"
-            redis "$ip_a" CLUSTER MEET "$ip_b" 6379
+            redis "$ip_a" CLUSTER MEET "$ip_b" <%= p('redis.tls.enabled') && p('redis.tls.dual-mode') ? 16379 : 6379 %>
         else
             log "Failed to resolve DNS for $a or $b"
         fi

--- a/jobs/cluster-7/templates/bin/post-deploy
+++ b/jobs/cluster-7/templates/bin/post-deploy
@@ -101,7 +101,7 @@ for ((i = 0; i < len; i++)); do
 
         if [ -n "$ip_a" ] && [ -n "$ip_b" ]; then
             log "Introducing $a ($ip_a) to $b ($ip_b)"
-            redis "$ip_a" CLUSTER MEET "$ip_b" 6379
+            redis "$ip_a" CLUSTER MEET "$ip_b" <%= p('redis.tls.enabled') && p('redis.tls.dual-mode') ? 16379 : 6379 %>
         else
             log "Failed to resolve DNS for $a or $b"
         fi


### PR DESCRIPTION
## Summary

- When TLS dual-mode is enabled, CLUSTER MEET used port 6379 causing
  nodes to calculate bus port as 16379 (6379+10000), but the actual
  cluster bus runs on 26379 (16379+10000). Nodes sent MEET messages
  that were never received, preventing cluster formation.
- Use the TLS port (16379) in CLUSTER MEET when dual-mode is active
  so the bus port resolves correctly to 26379.

## Affected jobs

- `cluster-6`
- `cluster-7`

## Test plan

- [x] Verified manually on live deployment: `CLUSTER MEET <ip> 16379`
  results in `cluster_known_nodes:6` and `cluster_state:ok`
- [x] Confirmed `CLUSTER MEET <ip> 6379` causes `cluster_known_nodes:1`
  and `cluster_stats_messages_received:0`